### PR TITLE
add possibility to make transitions smoother

### DIFF
--- a/Assets/Scenes/App.unity
+++ b/Assets/Scenes/App.unity
@@ -31962,6 +31962,7 @@ GameObject:
   - component: {fileID: 629393326}
   - component: {fileID: 629393325}
   - component: {fileID: 629393324}
+  - component: {fileID: 629393327}
   m_Layer: 5
   m_Name: score-game
   m_TagString: Untagged
@@ -32056,6 +32057,24 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 629393322}
   m_CullTransparentMesh: 1
+--- !u!114 &629393327
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 629393322}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8410d66681d6293449c4d8214c0bc119, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  mainImage: {fileID: 629393325}
+  text: {fileID: 1498994331}
+  increaseAlpha: 0
+  decreaseAlpha: 0
+  increaseSpeed: 25
+  decreaseSpeed: 25
 --- !u!1 &635332551
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/App.unity
+++ b/Assets/Scenes/App.unity
@@ -2775,6 +2775,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 41037104}
+  - component: {fileID: 41037105}
   m_Layer: 5
   m_Name: Main-menu
   m_TagString: Untagged
@@ -2802,6 +2803,23 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &41037105
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 41037103}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8410d66681d6293449c4d8214c0bc119, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  images: []
+  increaseAlpha: 0
+  decreaseAlpha: 0
+  increaseSpeed: 6
+  decreaseSpeed: 6
 --- !u!1 &41159972
 GameObject:
   m_ObjectHideFlags: 0
@@ -31962,7 +31980,6 @@ GameObject:
   - component: {fileID: 629393326}
   - component: {fileID: 629393325}
   - component: {fileID: 629393324}
-  - component: {fileID: 629393327}
   m_Layer: 5
   m_Name: score-game
   m_TagString: Untagged
@@ -32057,24 +32074,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 629393322}
   m_CullTransparentMesh: 1
---- !u!114 &629393327
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 629393322}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8410d66681d6293449c4d8214c0bc119, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  mainImage: {fileID: 629393325}
-  text: {fileID: 1498994331}
-  increaseAlpha: 0
-  decreaseAlpha: 0
-  increaseSpeed: 25
-  decreaseSpeed: 25
 --- !u!1 &635332551
 GameObject:
   m_ObjectHideFlags: 0
@@ -36175,6 +36174,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 704464120}
+  - component: {fileID: 704464121}
   m_Layer: 5
   m_Name: game-results
   m_TagString: Untagged
@@ -36205,6 +36205,23 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &704464121
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 704464119}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8410d66681d6293449c4d8214c0bc119, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  images: []
+  increaseAlpha: 0
+  decreaseAlpha: 0
+  increaseSpeed: 6
+  decreaseSpeed: 6
 --- !u!1 &706374117
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Tools.meta
+++ b/Assets/Scripts/Tools.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6cd6f356155e4fb4a8429b1fffad2c73
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Tools/Appear.cs
+++ b/Assets/Scripts/Tools/Appear.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections;
-using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -23,6 +20,19 @@ public class Appear : MonoBehaviour
 
     [SerializeField]
     private float decreaseSpeed = 10;
+
+    public void startAppearing()
+    {
+        this.gameObject.SetActive(true);
+        this.increaseAlpha = true;
+        this.decreaseAlpha = false;
+    }
+
+    public void startDisappearing()
+    {
+        this.increaseAlpha = false;
+        this.decreaseAlpha = true;
+    }
 
     void Start()
     {
@@ -58,6 +68,10 @@ public class Appear : MonoBehaviour
             {
                 text.alpha -= decreaseSpeed * Time.deltaTime;
             }
+            if (text.alpha <= 0)
+            {
+                this.gameObject.SetActive(false);
+            }
         }
     }
 
@@ -86,6 +100,10 @@ public class Appear : MonoBehaviour
             Color c = image.color;
             c.a -= decreaseSpeed * Time.deltaTime;
             image.color = c;
+            if (c.a <= 0)
+            {
+                this.gameObject.SetActive(false);
+            }
         }
     }
 }

--- a/Assets/Scripts/Tools/Appear.cs
+++ b/Assets/Scripts/Tools/Appear.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class Appear : MonoBehaviour
+{
+    [SerializeField]
+    private Image[] images;
+
+    private TextMeshProUGUI[] texts;
+
+    [SerializeField]
+    private bool increaseAlpha;
+
+    [SerializeField]
+    private bool decreaseAlpha;
+
+    [SerializeField]
+    private float increaseSpeed = 10;
+
+    [SerializeField]
+    private float decreaseSpeed = 10;
+
+    void Start()
+    {
+        texts = GetComponentsInChildren<TextMeshProUGUI>();
+        images = GetComponentsInChildren<Image>();
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        foreach (TextMeshProUGUI text in texts)
+        {
+            handleText(text);
+        }
+        foreach (Image image in images)
+        {
+            handleImage(image);
+        }
+    }
+
+    private void handleText(TextMeshProUGUI text)
+    {
+        if (increaseAlpha)
+        {
+            if (text.alpha < 1)
+            {
+                text.alpha += increaseSpeed * Time.deltaTime;
+            }
+        }
+        if (decreaseAlpha)
+        {
+            if (text.alpha > 0)
+            {
+                text.alpha -= decreaseSpeed * Time.deltaTime;
+            }
+        }
+    }
+
+    private void handleImage(Image image)
+    {
+        if (increaseAlpha)
+        {
+            Color c = image.color;
+            if (c.a < .3f)
+            {
+                c.a = 0.3f;
+            }
+            if (c.a < 1)
+            {
+                c.a += increaseSpeed * Time.deltaTime;
+                if (c.a > 1)
+                {
+                    c.a = 1;
+                }
+                //c.a=Math.Clamp(c.a,c.a,1);
+                image.color = c;
+            }
+        }
+        if (decreaseAlpha)
+        {
+            Color c = image.color;
+            c.a -= decreaseSpeed * Time.deltaTime;
+            image.color = c;
+        }
+    }
+}

--- a/Assets/Scripts/Tools/Appear.cs.meta
+++ b/Assets/Scripts/Tools/Appear.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8410d66681d6293449c4d8214c0bc119
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UIController.cs
+++ b/Assets/Scripts/UIController.cs
@@ -10,17 +10,20 @@ public class UIController : MonoBehaviour
     [SerializeField]
     private GameObject resultOverview;
     private MAIN_UI_STATE currentState = MAIN_UI_STATE.MAIN_MENU;
+    private Dictionary<MAIN_UI_STATE, GameObject> mainObjectsMap =
+        new Dictionary<MAIN_UI_STATE, GameObject>();
+
+    private void Start()
+    {
+        mainObjectsMap.Add(MAIN_UI_STATE.MAIN_MENU, mainMenu);
+        mainObjectsMap.Add(MAIN_UI_STATE.RESULT_OVERVIEW, resultOverview);
+    }
 
     public void switchToMenu(string newState)
     {
-        this.currentState =  (MAIN_UI_STATE)System.Enum.Parse(typeof(MAIN_UI_STATE), newState);
-        updateUI();
-    }
-
-    private void updateUI()
-    {
-        mainMenu.SetActive(currentState == MAIN_UI_STATE.MAIN_MENU);
-        resultOverview.SetActive(currentState == MAIN_UI_STATE.RESULT_OVERVIEW);
+        mainObjectsMap[currentState].GetComponent<Appear>().startDisappearing();
+        this.currentState = (MAIN_UI_STATE)System.Enum.Parse(typeof(MAIN_UI_STATE), newState);
+        mainObjectsMap[currentState].GetComponent<Appear>().startAppearing();
     }
 
     public enum MAIN_UI_STATE


### PR DESCRIPTION
Transitions can now be made smoother by vanishing in the new element and at the same time vanish out the old one. It is applied to transition mainMenu <-> resultsOverview.